### PR TITLE
Add Submail

### DIFF
--- a/src/Gateways/SubmailGateway.php
+++ b/src/Gateways/SubmailGateway.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the overtrue/easy-sms.
+ * (c) overtrue <i@overtrue.me>
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\EasySms\Gateways;
+
+use Overtrue\EasySms\HasHttpRequest;
+
+/**
+ * Class SubmailGateway.
+ */
+class SubmailGateway extends Gateway{
+
+    use HasHttpRequest;
+
+    const ENDPOINT_TEMPLATE = 'https://api.mysubmail.com/message/%s.%s';
+    const ENDPOINT_FORMAT = 'json';
+
+    /**
+     * Send a short message.
+     *
+     * @param string|int $to
+     * @param string     $message
+     * @param array      $data
+     *
+     * @return mixed
+     */
+    public function send($to, $message, array $data = [])
+    {
+        $endpoint = $this->buildEndpoint('xsend');
+        return $this->post($endpoint, [
+            'appid' => $this->config->get('app_id'),
+            'signature' => $this->config->get('app_key'),
+            'project' => $this->config->get('project'),
+            'to' => $to,
+            'vars' => json_encode($data),
+        ]);
+    }
+
+    /**
+     * Build endpoint url.
+     *
+     * @param string $type
+     * @param string $resource
+     * @param string $function
+     *
+     * @return string
+     */
+    protected function buildEndpoint($function)
+    {
+        return sprintf(self::ENDPOINT_TEMPLATE,$function, self::ENDPOINT_FORMAT);
+    }
+}

--- a/src/Gateways/SubmailGateway.php
+++ b/src/Gateways/SubmailGateway.php
@@ -14,7 +14,8 @@ use Overtrue\EasySms\HasHttpRequest;
 /**
  * Class SubmailGateway.
  */
-class SubmailGateway extends Gateway{
+class SubmailGateway extends Gateway
+{
 
     use HasHttpRequest;
 
@@ -45,8 +46,6 @@ class SubmailGateway extends Gateway{
     /**
      * Build endpoint url.
      *
-     * @param string $type
-     * @param string $resource
      * @param string $function
      *
      * @return string

--- a/tests/Gateways/SubmailGatewayTest.php
+++ b/tests/Gateways/SubmailGatewayTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the overtrue/easy-sms.
+ * (c) overtrue <i@overtrue.me>
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\EasySms\Tests\Gateways;
+
+use Overtrue\EasySms\Gateways\SubmailGateway;
+use Overtrue\EasySms\Tests\TestCase;
+
+class SubmailGatewayTest extends TestCase
+{
+    public function testSend()
+    {
+        $gateway = \Mockery::mock(SubmailGateway::class.'[post]', [[
+            'app_id' => 'mock-app-id',
+            'app_key' => 'mock-app-key',
+            'project' => 'mock-project'
+        ]])->shouldAllowMockingProtectedMethods();
+
+        $gateway->expects()->post('https://api.mysubmail.com/message/xsend.json', [
+            'appid' => 'mock-app-id',
+            'signature' => 'mock-app-key',
+            'project' => 'mock-project',
+            'to' => 18188888888,
+            'vars' => json_encode(array(['code'=>'123456','time'=>'15'])),
+        ])->andReturn('mock-result')->once();
+
+        $this->assertSame('mock-result', $gateway->send(18188888888, '',array(['code'=>'123456','time'=>'15'])));
+    }
+}


### PR DESCRIPTION
新增服务商submail


submail模板短信的 xsend接口，  $data参数对应 submail接口vars


调用示例

```php
$config = [
    'gateways' => [
        'submail' => [
            'app_id' => '12345',
            'app_key' => 'xxxxxxxxxxxx',
            'project' => 'F2w0X2'
        ],
    ],
];

$easySms = new EasySms($config);

$response = $easySms->gateway('submail')->send(12888888888, '', [
        'code' => '147258',
        'time' => '5'
    ]);
```
 