### PR TITLE
Add YunTongXun

### DIFF
--- a/src/Gateways/YunTongXunGateway.php
+++ b/src/Gateways/YunTongXunGateway.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the overtrue/easy-sms.
+ * (c) wwp66650 <wwp66650@gmail.com>
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\EasySms\Gateways;
+
+use Overtrue\EasySms\HasHttpRequest;
+
+class YunTongXunGateway extends Gateway
+{
+    use HasHttpRequest;
+
+    const ENDPOINT_TEMPLATE = 'https://%s:%s/%s/%s/%s/%s/%s?sig=%s';
+    const SDK_VERSION = '2013-12-26';
+
+    protected $server_ip;
+    protected $server_port;
+    protected $account_sid;
+
+    /**
+     * YunTongXunGateway constructor.
+     *
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        $this->server_ip = $config['server_ip'];
+        $this->server_port = $config['server_port'];
+        $this->account_sid = $config['account_sid'];
+        parent::__construct($config);
+    }
+
+    /**
+     * Send a short message.
+     *
+     * @param string|int $to
+     * @param string     $template_id
+     * @param array      $data
+     *
+     * @return mixed
+     */
+    public function send($to, $template_id, array $data = [])
+    {
+        $datetime = date('YmdHis');
+
+        $endpoint = $this->buildEndpoint('SMS', 'TemplateSMS', $datetime);
+
+        return $this->request('post', $endpoint, [
+            'json' => [
+                'to' => $to,
+                'templateId' => $template_id,
+                'appId' => $this->config->get('app_id'),
+                'datas' => $data
+            ],
+            'headers' => [
+                "Accept" => 'application/json',
+                "Content-Type" => 'application/json;charset=utf-8',
+                "Authorization" => base64_encode($this->account_sid . ":" . $datetime),
+            ],
+        ]);
+    }
+
+    /**
+     * Build endpoint url.
+     *
+     * @param string $type
+     * @param string $resource
+     * @param string $datetime
+     *
+     * @return string
+     */
+    protected function buildEndpoint($type, $resource, $datetime)
+    {
+        $account_type = $this->config->get('is_sub_account') ? 'SubAccounts' : 'Accounts';
+        // 大写的sig参数
+        $sig = strtoupper(md5($this->account_sid . $this->config->get('account_token') . $datetime));
+
+        return sprintf(self::ENDPOINT_TEMPLATE, $this->server_ip, $this->server_port, self::SDK_VERSION, $account_type, $this->account_sid, $type, $resource, $sig);
+    }
+}

--- a/tests/Gateways/YunTongXunGatewayTest.php
+++ b/tests/Gateways/YunTongXunGatewayTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the overtrue/easy-sms.
+ * (c) wwp66650 <wwp66650@gmail.com>
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\EasySms\Tests\Gateways;
+
+use Overtrue\EasySms\Gateways\YunTongXunGateway;
+use Overtrue\EasySms\Tests\TestCase;
+
+class YunTongXunGatewayTest extends TestCase
+{
+    public function testSend()
+    {
+        $gateway = \Mockery::mock(YunTongXunGateway::class . '[request]', [[
+            'is_sub_account' => false,
+            'account_sid' => 'mock-account-sid',
+            'account_token' => 'mock-account-token',
+            'app_id' => 'mock-app-id',
+            'server_ip' => 'app.cloopen.com',
+            'server_port' => '8883',
+        ]])->shouldAllowMockingProtectedMethods();
+
+        $hash = date('YmdHis');
+        $sig = strtoupper(md5('mock-account-sid' . 'mock-account-token' . $hash));
+
+        $gateway->expects()->request('post', 'https://app.cloopen.com:8883/2013-12-26/Accounts/mock-account-sid/SMS/TemplateSMS?sig=' . $sig, [
+            'json' => [
+                'to' => 18888888888,
+                'templateId' => 5589,
+                'appId' => 'mock-app-id',
+                'datas' => ['mock-data-1', 'mock-data-2']
+            ],
+            'headers' => [
+                "Accept" => 'application/json',
+                "Content-Type" => 'application/json;charset=utf-8',
+                "Authorization" => base64_encode('mock-account-sid:' . $hash),
+            ],
+        ])->andReturn('mock-result')->once();
+
+        $this->assertSame('mock-result', $gateway->send(18888888888, 5589, ['mock-data-1', 'mock-data-2']));
+    }
+}


### PR DESCRIPTION
新增服务商 YunTongXun（云通讯）

调用示例
````
$config = [
    'gateways' => [
        'yun-tong-xun' => [
            'is_sub_account' => false,// 如果是子账户，这里填 true
            'account_sid' => '8xxxxxxxxxxxxxxxx4',// ACCOUNT SID
            'account_token' => 'dxxxxxxxxxxxxxxxxxxx7',// AUTH TOKEN
            'app_id' => 'axxxxxxxxxxxxxxx3',// AppID
            'server_ip' => 'app.cloopen.com',// 请求地址
            'server_port' => '8883',// 请求端口
        ],
    ],
];
$easySms = new EasySms($config);
$response = $easySms->gateway('yun-tong-xun')->send(13699999991, 5519 , ['wwp66650','余额','888,888,888.88']);// 第二个参数为模板ID，第三个参数为模板替换数据

````