### PR TITLE
Add AliDayu

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $easySms->gateway('error-log')->send(19188888888, 'hello world!');
 - [YunPian](https://github.com/overtrue/easy-sms/wiki/GateWays---YunPian)
 - [Submail](https://github.com/overtrue/easy-sms/wiki/GateWays---Submail)
 - [Luosimao](https://github.com/overtrue/easy-sms/wiki/GateWays---Luosimao)
+- [AliDayu](https://github.com/overtrue/easy-sms/wiki/GateWays---AliDayu)
 - Todo
 
 

--- a/src/Gateways/AliDayuGateway.php
+++ b/src/Gateways/AliDayuGateway.php
@@ -67,7 +67,6 @@ class AliDayuGateway extends Gateway
                 $stringToBeSigned .= "$key$value";
             }
         }
-        unset($key, $value);
         $stringToBeSigned .= $this->config->get('app_secret');
         return strtoupper(md5($stringToBeSigned));
     }

--- a/src/Gateways/AliDayuGateway.php
+++ b/src/Gateways/AliDayuGateway.php
@@ -34,7 +34,7 @@ class AliDayuGateway extends Gateway
      */
     public function send($to, $message, array $data = [])
     {
-        $reqParams = [
+        $params = [
             'method' => self::ENDPOINT_METHOD,
             'format' => self::ENDPOINT_FORMAT,
             'v' => self::ENDPOINT_VERSION,
@@ -47,8 +47,8 @@ class AliDayuGateway extends Gateway
             'rec_num' => strval($to),
             'sms_param' => json_encode($data)
         ];
-        $reqParams['sign'] = $this->generateSign($reqParams);
-        return $this->post(self::ENDPOINT_URL, $reqParams);
+        $params['sign'] = $this->generateSign($params);
+        return $this->post(self::ENDPOINT_URL, $params);
     }
 
     /**
@@ -62,14 +62,12 @@ class AliDayuGateway extends Gateway
     {
         ksort($params);
         $stringToBeSigned = $this->config->get('app_secret');
-        foreach ($params as $k => $v)
-        {
-            if (is_string($v) && "@" != substr($v, 0, 1))
-            {
-                $stringToBeSigned .= "$k$v";
+        foreach ($params as $key => $value) {
+            if (is_string($value) && "@" != substr($value, 0, 1)) {
+                $stringToBeSigned .= "$key$value";
             }
         }
-        unset($k, $v);
+        unset($key, $value);
         $stringToBeSigned .= $this->config->get('app_secret');
         return strtoupper(md5($stringToBeSigned));
     }

--- a/src/Gateways/AliDayuGateway.php
+++ b/src/Gateways/AliDayuGateway.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the overtrue/easy-sms.
+ * (c) overtrue <i@overtrue.me>
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\EasySms\Gateways;
+
+use Overtrue\EasySms\HasHttpRequest;
+
+/**
+ * Class AliDayuGateway.
+ */
+class AliDayuGateway extends Gateway
+{
+    use HasHttpRequest;
+
+    const ENDPOINT_URL = 'https://eco.taobao.com/router/rest';
+    const ENDPOINT_METHOD = 'alibaba.aliqin.fc.sms.num.send';
+    const ENDPOINT_VERSION = '2.0';
+    const ENDPOINT_FORMAT = 'json';
+
+    /**
+     * Send a short message.
+     *
+     * @param string|int $to
+     * @param string     $message
+     * @param array      $data
+     *
+     * @return mixed
+     */
+    public function send($to, $message, array $data = [])
+    {
+        $reqParams = [
+            'method' => self::ENDPOINT_METHOD,
+            'format' => self::ENDPOINT_FORMAT,
+            'v' => self::ENDPOINT_VERSION,
+            'sign_method' => 'md5',
+            'timestamp' => date("Y-m-d H:i:s"),
+            'sms_type' => 'normal',
+            'sms_free_sign_name' => $this->config->get('sign_name'),
+            'app_key' => $this->config->get('app_key'),
+            'sms_template_code' => $this->config->get('template_code'),
+            'rec_num' => strval($to),
+            'sms_param' => json_encode($data)
+        ];
+        $reqParams['sign'] = $this->generateSign($reqParams);
+        return $this->post(self::ENDPOINT_URL, $reqParams);
+    }
+
+    /**
+     * Generate Sign.
+     *
+     * @param array $params
+     *
+     * @return string
+     */
+    protected function generateSign($params)
+    {
+        ksort($params);
+        $stringToBeSigned = $this->config->get('app_secret');
+        foreach ($params as $k => $v)
+        {
+            if (is_string($v) && "@" != substr($v, 0, 1))
+            {
+                $stringToBeSigned .= "$k$v";
+            }
+        }
+        unset($k, $v);
+        $stringToBeSigned .= $this->config->get('app_secret');
+        return strtoupper(md5($stringToBeSigned));
+    }
+}

--- a/tests/Gateways/AliDayuGatewayTest.php
+++ b/tests/Gateways/AliDayuGatewayTest.php
@@ -16,13 +16,42 @@ class AliDayuGatewayTest extends TestCase
 {
     public function testSend()
     {
-        $gateway = new AliDayuGateway([
-            'app_key' => 'api-key',
-            'app_secret' => 'api-secret',
-            'sign_name' => 'api-sign-name',
-            'template_code' => 'template-code',
-        ]);
-        $this->assertStringStartsWith('{"error_response"',$gateway->send(18888888888,'',array('code'=>'123456','time'=>'15')));
+        $gateway = \Mockery::mock(AliDayuGateway::class.'[post]', [[
+            'app_key' => 'mock-api-key',
+            'app_secret' => 'mock-api-secret',
+            'sign_name' => 'mock-api-sign-name',
+            'template_code' => 'mock-template-code',
+        ]])->shouldAllowMockingProtectedMethods();
+
+        $params= [
+            'method' => 'alibaba.aliqin.fc.sms.num.send',
+            'format' => 'json',
+            'v' => '2.0',
+            'sign_method' => 'md5',
+            'timestamp' => date("Y-m-d H:i:s"),
+            'sms_type' => 'normal',
+            'sms_free_sign_name' => 'mock-api-sign-name',
+            'app_key' => 'mock-api-key',
+            'sms_template_code' => 'mock-template-code',
+            'rec_num' => strval(18888888888),
+            'sms_param' => json_encode(array('code'=>'123456','time'=>'15'))
+        ];
+        $params['sign']=$this->generateSign($params);
+        $gateway->expects()->post('https://eco.taobao.com/router/rest', $params)->andReturn('mock-result')->once();
+        $this->assertSame('mock-result', $gateway->send(18888888888,'',array('code'=>'123456','time'=>'15')));
     }
 
+    protected function generateSign($params)
+    {
+        ksort($params);
+        $stringToBeSigned = 'mock-api-secret';
+        foreach ($params as $key => $value) {
+            if(is_string($key) && "@" != substr($value, 0, 1)) {
+                $stringToBeSigned .= "$key$value";
+            }
+        }
+        unset($key, $value);
+        $stringToBeSigned .= 'mock-api-secret';
+        return strtoupper(md5($stringToBeSigned));
+    }
 }

--- a/tests/Gateways/AliDayuGatewayTest.php
+++ b/tests/Gateways/AliDayuGatewayTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the overtrue/easy-sms.
+ * (c) overtrue <i@overtrue.me>
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\EasySms\Tests\Gateways;
+
+use Overtrue\EasySms\Gateways\AliDayuGateway;
+use Overtrue\EasySms\Tests\TestCase;
+
+class AliDayuGatewayTest extends TestCase
+{
+    public function testSend()
+    {
+        $gateway = new AliDayuGateway([
+            'app_key' => 'api-key',
+            'app_secret' => 'api-secret',
+            'sign_name' => 'api-sign-name',
+            'template_code' => 'template-code',
+        ]);
+        $this->assertStringStartsWith('{"error_response"',$gateway->send(18888888888,'',array('code'=>'123456','time'=>'15')));
+    }
+
+}

--- a/tests/Gateways/AliDayuGatewayTest.php
+++ b/tests/Gateways/AliDayuGatewayTest.php
@@ -50,7 +50,6 @@ class AliDayuGatewayTest extends TestCase
                 $stringToBeSigned .= "$key$value";
             }
         }
-        unset($key, $value);
         $stringToBeSigned .= 'mock-api-secret';
         return strtoupper(md5($stringToBeSigned));
     }


### PR DESCRIPTION
新增服务商阿里大于

官方文档：https://api.alidayu.com/docs/api.htm?spm=a3142.7395905.4.6.VgjgAz&apiId=25450

调用示例
```php
   $config = [
            'gateways' => [
                'ali-dayu' => [
                    'app_key' => '123456',
                    'app_secret' => '123456abcxyz654321',
                    'sign_name' => 'SignName',  //签名
                    'template_code' => 'SMS_123456',//模板id

                ],
            ],
        ];
        $easySms = new EasySms($config);
        $easySms->gateway('ali-dayu')->send(18888888888,'',['code' => '123456','time' => '15']);／／第2个参数未使用， 第3个参数对应模板内的变量

```