### PR TITLE
fix: 当自定义 gateway 没有传入参数时无法使用问题

### DIFF
--- a/src/Messenger.php
+++ b/src/Messenger.php
@@ -117,6 +117,7 @@ class Messenger
                 $setting = [];
             }
 
+            $formatted[$gateway] = $setting;
             $globalSetting = $config->get("gateways.{$gateway}", []);
 
             if (is_string($gateway) && !empty($globalSetting) && is_array($setting)) {


### PR DESCRIPTION
例如自定义了一个不需要参数 monolog gateway

```
new EasySms([
    'default'  => [
        'gateways' => ['monolog'],
    ],
    'gateways' => [
        'monolog' => [],
    ],
]);
```

调用 send 会返回一个空数组，原因在于 [formatGateways](https://github.com/overtrue/easy-sms/blob/master/src/Messenger.php#L122) 处理时忽略了空配置的 gateway。