### PR TITLE
键名不带有点语法 返回默认值

### DIFF
--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -52,6 +52,10 @@ class Config implements ArrayAccess
         if (isset($config[$key])) {
             return $config[$key];
         }
+        
+        if (strpos($key, '.') === false) {
+            return $default;
+        }
 
         foreach (explode('.', $key) as $segment) {
             if (!is_array($config) || !array_key_exists($segment, $config)) {


### PR DESCRIPTION
判断不存在的键名 并且 键名不带有语法 返回默认值