### PR TITLE
修改new Config错误导致的All the gateways have failed错误

### DIFF
--- a/src/Messenger.php
+++ b/src/Messenger.php
@@ -61,7 +61,7 @@ class Messenger
                 $results[$gateway] = [
                     'gateway' => $gateway,
                     'status' => self::STATUS_SUCCESS,
-                    'result' => $this->easySms->gateway($gateway)->send($to, $message, new Config($gateways[$gateway])),
+                    'result' => $this->easySms->gateway($gateway)->send($to, $message,new Config($this->easySms->getConfig()->get("gateways.{$gateway}"))),
                 ];
                 $isSuccessful = true;
 


### PR DESCRIPTION
https://github.com/overtrue/easy-sms/blob/49d99629b95144341789059e8ce577ea5f90f4ae/src/Messenger.php#L64

这个地方，new Config($gateways[$gateway])，其中 $gateways[$gateway]是错误的。
可以改为：new Config($this->easySms->getConfig()->get("gateways.{$gateway}"))