### PR TITLE
fix: remove unnecessary code

### DIFF
--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -45,10 +45,6 @@ class Config implements ArrayAccess
     {
         $config = $this->config;
 
-        if (is_null($key)) {
-            return null;
-        }
-
         if (isset($config[$key])) {
             return $config[$key];
         }


### PR DESCRIPTION
The parameter `key` do not set default value, so the value of parameter `key` will not be `null`, even if the caller pass the value of `null`, the code also works well.