### PR TITLE
自动化测试

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  phpunit:
+    strategy:
+      matrix:
+        php_version: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup PHP environment
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php_version }}
+        coverage: xdebug
+    - name: Install dependencies
+      run: composer install
+    - name: PHPUnit check
+      run: ./vendor/bin/phpunit --coverage-text

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php_version: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php_version: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php_version: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
+        php_version: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.lock
 .idea
 /index.php
 /config.php
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^7.5 || ^8.5 || ^9.5",
-        "mockery/mockery": "1.3.1"
+        "phpunit/phpunit": "^5.7 || ^7.5 || ^8.5.19 || ^9.5.8",
+        "mockery/mockery": "~1.3.3 || ^1.4.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^7.5",
+        "phpunit/phpunit": "^5.7 || ^7.5 || ^8.5 || ^9.5",
         "mockery/mockery": "1.3.1"
     },
     "autoload": {

--- a/src/Gateways/AliyunGateway.php
+++ b/src/Gateways/AliyunGateway.php
@@ -97,7 +97,7 @@ class AliyunGateway extends Gateway
     {
         ksort($params);
         $accessKeySecret = $this->config->get('access_key_secret');
-        $stringToSign = 'GET&%2F&'.urlencode(http_build_query($params, null, '&', PHP_QUERY_RFC3986));
+        $stringToSign = 'GET&%2F&'.urlencode(http_build_query($params, '', '&', PHP_QUERY_RFC3986));
 
         return base64_encode(hash_hmac('sha1', $stringToSign, $accessKeySecret.'&', true));
     }

--- a/src/Gateways/YunpianGateway.php
+++ b/src/Gateways/YunpianGateway.php
@@ -57,7 +57,9 @@ class YunpianGateway extends Gateway
             $function = 'tpl_single_send';
             $data = [];
 
-            foreach ($message->getData($this) ?? [] as $key => $value) {
+            $templateData = $message->getData($this);
+            $templateData = isset($templateData) ? $templateData : [];
+            foreach ($templateData as $key => $value) {
                 $data[] = urlencode('#'.$key.'#') . '=' . urlencode($value);
             }
 

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -108,6 +108,7 @@ class PhoneNumber implements \Overtrue\EasySms\Contracts\PhoneNumberInterface
      *
      * @since 5.4.0
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getUniversalNumber();

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -79,6 +79,7 @@ class Config implements ArrayAccess
      *
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->config);
@@ -97,6 +98,7 @@ class Config implements ArrayAccess
      *
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
@@ -116,6 +118,7 @@ class Config implements ArrayAccess
      *
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (isset($this->config[$offset])) {
@@ -134,6 +137,7 @@ class Config implements ArrayAccess
      *
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if (isset($this->config[$offset])) {

--- a/tests/Gateways/ErrorlogGatewayTest.php
+++ b/tests/Gateways/ErrorlogGatewayTest.php
@@ -19,18 +19,11 @@ use Overtrue\EasySms\Tests\TestCase;
 
 class ErrorlogGatewayTest extends TestCase
 {
-    protected $logFile = 'easy-sms-error-log-mock-file.log';
-
-    public function tearDown()
-    {
-        parent::tearDown();
-        unlink($this->logFile);
-    }
-
     public function testSend()
     {
+        $logFile = 'easy-sms-error-log-mock-file.log';
         $gateway = new ErrorlogGateway([
-            'file' => $this->logFile,
+            'file' => $logFile,
         ]);
 
         $message = new Message([
@@ -40,10 +33,13 @@ class ErrorlogGatewayTest extends TestCase
 
         $gateway->send(new PhoneNumber(new PhoneNumber(18188888888)), $message, new Config());
 
-        $this->assertTrue(file_exists($this->logFile));
-        $this->assertContains(
-            'to: 18188888888 | message: "This is a test message."  | template: "" | data: {"foo":"bar"}',
-            file_get_contents($this->logFile)
+        $this->assertTrue(file_exists($logFile));
+        $this->assertFalse(
+            strpos(
+                'to: 18188888888 | message: "This is a test message."  | template: "" | data: {"foo":"bar"}',
+                file_get_contents($logFile)
+            )
         );
+        unlink($logFile);
     }
 }

--- a/tests/Gateways/JuheGatewayTest.php
+++ b/tests/Gateways/JuheGatewayTest.php
@@ -30,7 +30,7 @@ class JuheGatewayTest extends TestCase
         $params = [
             'mobile' => 18188888888,
             'tpl_id' => 'mock-tpl-id',
-            'tpl_value' => http_build_query(['#code#' => 1234]),
+            'tpl_value' => urldecode(http_build_query(['#code#' => 1234])),
             'dtype' => 'json',
             'key' => 'mock-key',
         ];

--- a/tests/Gateways/QcloudGatewayTest.php
+++ b/tests/Gateways/QcloudGatewayTest.php
@@ -50,10 +50,8 @@ class QcloudGatewayTest extends TestCase
             ], [
                 'Response' => [
                     "Error" => [
-                        [
-                            "Code" => "AuthFailure.SignatureFailure",
-                            "Message" => "The provided credentials could not be validated. Please check your signature is correct.",
-                        ]
+                        "Code" => "AuthFailure.SignatureFailure",
+                        "Message" => "The provided credentials could not be validated. Please check your signature is correct.",
                     ]
                 ],
                 'RequestId' => '0dc99542-c61a-4a16-9545-2b967e2c980a'
@@ -86,8 +84,8 @@ class QcloudGatewayTest extends TestCase
         ], $gateway->send(new PhoneNumber(18888888888), $message, $config));
 
         $this->expectException(GatewayErrorException::class);
-        $this->expectExceptionCode(1001);
-        $this->expectExceptionMessage('sig校验失败');
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('The provided credentials could not be validated. Please check your signature is correct.');
 
         $gateway->send(new PhoneNumber(18888888888), $message, $config);
     }

--- a/tests/Gateways/SmsbaoGatewayTest.php
+++ b/tests/Gateways/SmsbaoGatewayTest.php
@@ -72,7 +72,7 @@ class SmsbaoGatewayTest extends TestCase
         $params = [
             'u' => 'mock-user',
             'p' => md5('mock-password'),
-            'm' => '+8618188888888',
+            'm' => '+8518188888888',
             'c' => 'This is a test message.'
         ];
 
@@ -87,11 +87,11 @@ class SmsbaoGatewayTest extends TestCase
 
         $this->assertSame(
             '0',
-            $gateway->send(new PhoneNumber(18188888888, 86), $message, $config)
+            $gateway->send(new PhoneNumber(18188888888, 85), $message, $config)
         );
 
         $this->expectException(GatewayErrorException::class);
         $this->expectExceptionCode(30);
-        $gateway->send(new PhoneNumber(18188888888, 86), $message, $config);
+        $gateway->send(new PhoneNumber(18188888888, 85), $message, $config);
     }
 }

--- a/tests/Support/ConfigTest.php
+++ b/tests/Support/ConfigTest.php
@@ -43,7 +43,7 @@ class ConfigTest extends TestCase
 
         $this->assertSame('bar', $config['foo']);
         $this->assertSame('bar', $config->get('foo'));
-        $this->assertNull($config->get(null));
+        $this->assertNull($config->get('key-not-exists'));
 
         $this->assertSame(9999, $config->get('bar.profile.id'));
         $this->assertSame('overtrue', $config->get('bar.profile.name'));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,17 +11,6 @@
 
 namespace Overtrue\EasySms\Tests;
 
-use Mockery;
-
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
-    {
-        Mockery::globalHelpers();
-    }
-
-    public function tearDown()
-    {
-        Mockery::close();
-    }
 }

--- a/tests/Traits/HasHttpRequestTest.php
+++ b/tests/Traits/HasHttpRequestTest.php
@@ -34,7 +34,7 @@ class HasHttpRequestTest extends TestCase
 
         $options = ['form_params' => ['foo' => 'bar']];
         $mockHttpClient->allows()->get('mock-endpoint', $options)->andReturn($mockResponse)->once();
-        $object->allows()->request(anyArgs())->passthru();
+        $object->shouldReceive('request')->withAnyArgs()->passthru();
 
         $this->assertSame('unwrapped-api-result', $object->request('get', 'mock-endpoint', $options));
     }
@@ -47,7 +47,7 @@ class HasHttpRequestTest extends TestCase
             'headers' => ['Content-Type' => 'Mock-Content-Type'],
             'query' => ['foo' => 'bar'],
         ])->andReturns('mock-result')->once();
-        $object->allows()->get(anyArgs())->passthru();
+        $object->shouldReceive('get')->withAnyArgs()->passthru();
 
         $response = $object->get('mock-endpoint', ['foo' => 'bar'], ['Content-Type' => 'Mock-Content-Type']);
 
@@ -62,7 +62,7 @@ class HasHttpRequestTest extends TestCase
             'headers' => ['Content-Type' => 'Mock-Content-Type'],
             'form_params' => ['foo' => 'bar'],
         ])->andReturns('mock-result')->once();
-        $object->allows()->post(anyArgs())->passthru();
+        $object->shouldReceive('post')->withAnyArgs()->passthru();
 
         $response = $object->post('mock-endpoint', ['foo' => 'bar'], ['Content-Type' => 'Mock-Content-Type']);
 
@@ -74,7 +74,7 @@ class HasHttpRequestTest extends TestCase
         $object = \Mockery::mock(DummyClassForHasHttpRequestTrait::class)
                 ->makePartial()
                 ->shouldAllowMockingProtectedMethods();
-        $object->allows()->getBaseOptions(anyArgs())->passthru();
+        $object->shouldReceive('getBaseOptions')->withAnyArgs()->passthru();
 
         $this->assertSame('http://mock-uri', $object->getBaseOptions()['base_uri']);
         $this->assertSame(5.0, $object->getBaseOptions()['timeout']);
@@ -83,7 +83,7 @@ class HasHttpRequestTest extends TestCase
         $object = \Mockery::mock(DummyTimeoutClassForHasHttpRequestTrait::class)
                 ->makePartial()
                 ->shouldAllowMockingProtectedMethods();
-        $object->allows()->getBaseOptions(anyArgs())->passthru();
+        $object->shouldReceive('getBaseOptions')->withAnyArgs()->passthru();
 
         $this->assertSame('http://mock-uri', $object->getBaseOptions()['base_uri']);
         $this->assertSame(30.0, $object->getBaseOptions()['timeout']);
@@ -94,7 +94,7 @@ class HasHttpRequestTest extends TestCase
         $object = \Mockery::mock(DummyClassForHasHttpRequestTrait::class)
             ->makePartial()
             ->shouldAllowMockingProtectedMethods();
-        $object->allows()->unwrapResponse(anyArgs())->passthru();
+        $object->shouldReceive('unwrapResponse')->withAnyArgs()->passthru();
 
         $body = ['foo' => 'bar'];
         $response = new Response(200, ['content-type' => 'application/json'], json_encode($body));
@@ -107,7 +107,7 @@ class HasHttpRequestTest extends TestCase
         $object = \Mockery::mock(DummyClassForHasHttpRequestTrait::class)
             ->makePartial()
             ->shouldAllowMockingProtectedMethods();
-        $object->allows()->unwrapResponse(anyArgs())->passthru();
+        $object->shouldReceive('unwrapResponse')->withAnyArgs()->passthru();
 
         $body = '<xml>
                     <foo>hello</foo>
@@ -123,7 +123,7 @@ class HasHttpRequestTest extends TestCase
         $object = \Mockery::mock(DummyClassForHasHttpRequestTrait::class)
             ->makePartial()
             ->shouldAllowMockingProtectedMethods();
-        $object->allows()->unwrapResponse(anyArgs())->passthru();
+        $object->shouldReceive('unwrapResponse')->withAnyArgs()->passthru();
 
         $body = 'something here.';
         $response = new Response(200, ['content-type' => 'text/plain'], $body);


### PR DESCRIPTION
这个合并修改了以下内容：
- 增加了 Github Action https://github.com/overtrue/easy-sms/commit/5b49b9c66e813223ba70d6ebbf6b71b888832862
- 修复测试用例 https://github.com/overtrue/easy-sms/commit/ede4a2eea494a075539587022bcb6bb14d975f8c
- 兼容 PHP 5.6 https://github.com/overtrue/easy-sms/commit/00304c71db0d86e7d24b344348dcb48b9577196e

  - 移除了 PHP 7.0 才支持的`null`合并运算符 https://github.com/overtrue/easy-sms/blob/11ab8082b8ca66be772780fb65e9652017b24608/src/Gateways/YunpianGateway.php#L60
- 兼容 PHP 8.0 https://github.com/overtrue/easy-sms/commit/69b73f262208f0d618b736b83e099de3e667cb55
  - 修复测试用例
- 兼容 PHP 8.1 https://github.com/overtrue/easy-sms/commit/e91df31445d2501d5e7ee9deaa8fcc806399f451
  - 添加注解 `#[\ReturnTypeWillChange]`
  - 参数类型修复，`http_build_query`的第二个参数由`null`改为`''` https://github.com/overtrue/easy-sms/blob/11ab8082b8ca66be772780fb65e9652017b24608/src/Gateways/AliyunGateway.php#L100
  - 修复测试用例