### PR TITLE
修复：测试失败时日志文件未删除

### DIFF
--- a/tests/Gateways/ErrorlogGatewayTest.php
+++ b/tests/Gateways/ErrorlogGatewayTest.php
@@ -19,11 +19,20 @@ use Overtrue\EasySms\Tests\TestCase;
 
 class ErrorlogGatewayTest extends TestCase
 {
+    protected $logFile = 'easy-sms-error-log-mock-file.log';
+
+    /**
+     * @after
+     */
+    public function removeLogFile()
+    {
+        unlink($this->logFile);
+    }
+
     public function testSend()
     {
-        $logFile = 'easy-sms-error-log-mock-file.log';
         $gateway = new ErrorlogGateway([
-            'file' => $logFile,
+            'file' => $this->logFile,
         ]);
 
         $message = new Message([
@@ -33,13 +42,12 @@ class ErrorlogGatewayTest extends TestCase
 
         $gateway->send(new PhoneNumber(new PhoneNumber(18188888888)), $message, new Config());
 
-        $this->assertTrue(file_exists($logFile));
-        $this->assertFalse(
+        $this->assertTrue(file_exists($this->logFile));
+        $this->assertNotFalse(
             strpos(
-                'to: 18188888888 | message: "This is a test message."  | template: "" | data: {"foo":"bar"}',
-                file_get_contents($logFile)
+                file_get_contents($this->logFile),
+                'to: 18188888888 | message: "This is a test message."  | template: "" | data: {"foo":"bar"}'
             )
         );
-        unlink($logFile);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,23 @@
 
 namespace Overtrue\EasySms\Tests;
 
+use Mockery;
+
 class TestCase extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @before
+     */
+    public function registerMockery()
+    {
+        Mockery::globalHelpers();
+    }
+
+    /**
+     * @after
+     */
+    public function closeMockery()
+    {
+        Mockery::close();
+    }
 }


### PR DESCRIPTION
- 通过`@before`和`@after`标注恢复原有`setUp`和`tearDown`的逻辑，确保测试完成后删除日志文件
- 修复日志内容断言，https://github.com/overtrue/easy-sms/pull/316 中包含的修改导致下面这个断言必定通过https://github.com/overtrue/easy-sms/blob/94de413f344fa02a850e3ccf6ce2c10e80934276/tests/Gateways/ErrorlogGatewayTest.php#L37-L42