### PR TITLE
修复阿里云发送包含有~特殊符号的短信时，因签名不匹配，导致发送失败问题

### DIFF
--- a/src/Gateways/AliyunGateway.php
+++ b/src/Gateways/AliyunGateway.php
@@ -92,12 +92,15 @@ class AliyunGateway extends Gateway
      * @param array $params
      *
      * @return string
+     *
+     * @see https://help.aliyun.com/document_detail/101343.html
      */
     protected function generateSign($params)
     {
         ksort($params);
         $accessKeySecret = $this->config->get('access_key_secret');
         $stringToSign = 'GET&%2F&'.urlencode(http_build_query($params, '', '&', PHP_QUERY_RFC3986));
+        $stringToSign = str_replace('%7E', '~', $stringToSign);
 
         return base64_encode(hash_hmac('sha1', $stringToSign, $accessKeySecret.'&', true));
     }


### PR DESCRIPTION
[阿里云短信请求签名文档地址](https://help.aliyun.com/document_detail/101343.html)
![构造待签名的请求串截图](https://user-images.githubusercontent.com/32324937/156344014-4381d166-d1aa-41e0-85cb-c0acdbb70a81.png "Magic Gardens")
