### PR TITLE
feat: 新增秒信短信网关

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [移动云MAS（黑名单模式）](https://mas.10086.cn)
 - [电信天翼云](https://www.ctyun.cn/document/10020426/10021544)
 - [微趣云](https://sms.weiqucloud.com/)
+- [秒信短信平台](http://www.51miaoxin.com)
 
 ## 环境需求
 

--- a/README.md
+++ b/README.md
@@ -1087,6 +1087,48 @@ $easySms->send(18888888888, [
 ]);
 ```
 
+### [秒信短信平台](http://www.51miaoxin.com)
+
+短信使用 `content` 或 `template`，根据消息内容自动选择发送方式：
+
+1. 设置 `template`（模板短信）→ 走模板接口（`/sms/sendTemplateParamd`）
+2. 未设置 `template` 但配置了 `signature_id`（固定签名）→ 走固定签名接口（`/sms/sendFixedSignature`）
+3. 未设置 `template` 且未配置 `signature_id`（自定义内容）→ 走发送接口（`/sms/send`）
+
+```php
+  'miaoxin' => [
+        'account'  => '',    // 服务商提供的账号
+        'secret'   => '',    // 服务商提供的密钥，用于生成 token 签名
+        // 'signature_id' => '',   // 可选，固定签名 ID（配置后自定义内容走固定签名接口）
+        // 'ref' => '',            // 可选，客户自定义编号，用于对账
+        // 'ext' => '',            // 可选，分机号
+        // 'schedule' => '',       // 可选，定时发送时间，模板短信专用
+        // 'endpoint' => '',       // 可选，接口地址覆盖，默认 http://www.51miaoxin.com
+    ],
+```
+
+发送示例（自定义内容）：
+
+```php
+$easySms->send(18888888888, [
+    'content'  => '【秒信】您的验证码是 6379，5 分钟内有效。',
+]);
+```
+
+发送示例（模板短信）：
+
+```php
+$easySms->send(18888888888, [
+    'template' => '模板ID',
+    'data' => [
+        '1234', // 对应模板的 param1、param2…按顺序填充，最多 8 个
+        '张三',
+    ],
+]);
+```
+
+> 自定义内容时如需固定签名，在配置中加上 `signature_id` 即可自动切换到固定签名发送方式。
+
 ## :heart: 支持我
 
 [![Sponsor me](https://github.com/overtrue/overtrue/blob/master/sponsor-me.svg?raw=true)](https://github.com/sponsors/overtrue)

--- a/src/Gateways/MiaoxinGateway.php
+++ b/src/Gateways/MiaoxinGateway.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the overtrue/easy-sms.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\EasySms\Gateways;
+
+use Overtrue\EasySms\Contracts\MessageInterface;
+use Overtrue\EasySms\Contracts\PhoneNumberInterface;
+use Overtrue\EasySms\Exceptions\GatewayErrorException;
+use Overtrue\EasySms\Support\Config;
+use Overtrue\EasySms\Traits\HasHttpRequest;
+
+/**
+ * Class MiaoxinGateway.
+ *
+ * @see http://docs.51miaoxin.com/sms/http_send.html
+ * @see http://docs.51miaoxin.com/sms/http_sign_fixed.html
+ * @see http://docs.51miaoxin.com/sms/http_template_parmed.html
+ */
+class MiaoxinGateway extends Gateway
+{
+    use HasHttpRequest;
+
+    public const ENDPOINT_HOST = 'http://www.51miaoxin.com';
+
+    public const SEND_PATH = '/sms/send';
+
+    public const FIXED_SIGNATURE_PATH = '/sms/sendFixedSignature';
+
+    public const TEMPLATE_PATH = '/sms/sendTemplateParamd';
+
+    public const SUCCESS_CODE = 0;
+
+    /**
+     * @return array
+     *
+     * @throws GatewayErrorException
+     */
+    public function send(PhoneNumberInterface $to, MessageInterface $message, Config $config)
+    {
+        $template = $message->getTemplate($this);
+        $content = $message->getContent($this);
+
+        if (! empty($template) && empty($content)) {
+            $params = $this->buildTemplateParams($to, $message, $config);
+            $path = self::TEMPLATE_PATH;
+        } elseif (! is_null($config->get('signature_id'))) {
+            $params = $this->buildContentParams($to, $message, $config, true);
+            $path = self::FIXED_SIGNATURE_PATH;
+        } else {
+            $params = $this->buildContentParams($to, $message, $config);
+            $path = self::SEND_PATH;
+        }
+
+        return $this->sendRequest($this->buildEndpoint($config, $path), $params);
+    }
+
+    /**
+     * Build the common protocol signature params.
+     *
+     * @return array
+     */
+    protected function buildBaseParams(Config $config)
+    {
+        $account = $config->get('account');
+        $secret = $config->get('secret');
+        $ts = date('YmdHis');
+
+        return [
+            'account' => $account,
+            'ts' => $ts,
+            'token' => $this->generateToken($account, $secret, $ts),
+        ];
+    }
+
+    /**
+     * Generate the SHA1 protocol token.
+     */
+    protected function generateToken(string $account, string $secret, string $ts): string
+    {
+        return sha1("account={$account}&ts={$ts}&secret={$secret}");
+    }
+
+    /**
+     * Build the endpoint URL with optional host override.
+     */
+    protected function buildEndpoint(Config $config, string $path): string
+    {
+        $host = rtrim($config->get('endpoint', self::ENDPOINT_HOST), '/');
+
+        return $host.$path;
+    }
+
+    /**
+     * Build params for custom or fixed-signature content sending.
+     *
+     * @return array
+     */
+    protected function buildContentParams(PhoneNumberInterface $to, MessageInterface $message, Config $config, bool $fixed = false)
+    {
+        $params = $this->buildBaseParams($config);
+
+        $params['mobiles'] = $to->getNumber();
+        $params['content'] = $message->getContent($this);
+
+        if ($fixed) {
+            $params['signatureId'] = $config->get('signature_id');
+        }
+
+        return $this->appendOptional($params, $config, ['ref', 'ext']);
+    }
+
+    /**
+     * Build params for template sending.
+     *
+     * @return array
+     */
+    protected function buildTemplateParams(PhoneNumberInterface $to, MessageInterface $message, Config $config)
+    {
+        $params = $this->buildBaseParams($config);
+
+        $params['templateId'] = $message->getTemplate($this);
+        $params['mobiles'] = $to->getNumber();
+
+        $index = 1;
+        foreach (array_values($message->getData($this)) as $value) {
+            if ($index > 8) {
+                break;
+            }
+            $params['param'.$index] = $value;
+            $index++;
+        }
+
+        return $this->appendOptional($params, $config, ['ref', 'ext', 'schedule']);
+    }
+
+    /**
+     * Append optional params when they are present in config.
+     *
+     * @return array
+     */
+    protected function appendOptional(array $params, Config $config, array $keys)
+    {
+        foreach ($keys as $key) {
+            $value = $config->get($key);
+            if ($value !== null && $value !== '') {
+                $params[$key] = $value;
+            }
+        }
+
+        return $params;
+    }
+
+    /**
+     * Post the request and validate the top-level code.
+     *
+     * @return array
+     *
+     * @throws GatewayErrorException
+     */
+    protected function sendRequest(string $endpoint, array $params)
+    {
+        $result = $this->post($endpoint, $params);
+
+        if ($result['code'] != self::SUCCESS_CODE) {
+            throw new GatewayErrorException($result['msg'], $result['code'], $result);
+        }
+
+        return $result;
+    }
+}

--- a/src/Gateways/MiaoxinGateway.php
+++ b/src/Gateways/MiaoxinGateway.php
@@ -46,12 +46,12 @@ class MiaoxinGateway extends Gateway
     public function send(PhoneNumberInterface $to, MessageInterface $message, Config $config)
     {
         $template = $message->getTemplate($this);
-        $content = $message->getContent($this);
+        $signatureId = $config->get('signature_id');
 
-        if (! empty($template) && empty($content)) {
+        if ($template !== null && $template !== '') {
             $params = $this->buildTemplateParams($to, $message, $config);
             $path = self::TEMPLATE_PATH;
-        } elseif (! is_null($config->get('signature_id'))) {
+        } elseif ($signatureId !== null && $signatureId !== '') {
             $params = $this->buildContentParams($to, $message, $config, true);
             $path = self::FIXED_SIGNATURE_PATH;
         } else {

--- a/src/Gateways/MiaoxinGateway.php
+++ b/src/Gateways/MiaoxinGateway.php
@@ -93,7 +93,7 @@ class MiaoxinGateway extends Gateway
      */
     protected function buildEndpoint(Config $config, string $path): string
     {
-        $host = rtrim($config->get('endpoint', self::ENDPOINT_HOST), '/');
+        $host = rtrim($config->get('endpoint') ?: self::ENDPOINT_HOST, '/');
 
         return $host.$path;
     }
@@ -159,7 +159,7 @@ class MiaoxinGateway extends Gateway
     }
 
     /**
-     * Post the request and validate the top-level code.
+     * Post the request and validate the response codes.
      *
      * @return array
      *
@@ -171,6 +171,12 @@ class MiaoxinGateway extends Gateway
 
         if ($result['code'] != self::SUCCESS_CODE) {
             throw new GatewayErrorException($result['msg'], $result['code'], $result);
+        }
+
+        foreach ($result['result'] ?? [] as $item) {
+            if ($item['code'] != self::SUCCESS_CODE) {
+                throw new GatewayErrorException($item['msg'], $item['code'], $result);
+            }
         }
 
         return $result;

--- a/tests/Gateways/MiaoxinGatewayTest.php
+++ b/tests/Gateways/MiaoxinGatewayTest.php
@@ -39,7 +39,7 @@ class MiaoxinGatewayTest extends TestCase
                 'code' => MiaoxinGateway::SUCCESS_CODE,
                 'msg' => '发送成功',
                 'total' => 1,
-                'results' => [
+                'result' => [
                     ['mobile' => '18188888888', 'order_id' => '1839347820929302091', 'code' => 0, 'msg' => '处理中'],
                 ],
             ], [
@@ -54,7 +54,7 @@ class MiaoxinGatewayTest extends TestCase
             'code' => MiaoxinGateway::SUCCESS_CODE,
             'msg' => '发送成功',
             'total' => 1,
-            'results' => [
+            'result' => [
                 ['mobile' => '18188888888', 'order_id' => '1839347820929302091', 'code' => 0, 'msg' => '处理中'],
             ],
         ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
@@ -87,7 +87,7 @@ class MiaoxinGatewayTest extends TestCase
                 'code' => MiaoxinGateway::SUCCESS_CODE,
                 'msg' => '发送成功',
                 'total' => 1,
-                'results' => [],
+                'result' => [],
             ])->once();
 
         $message = new Message(['content' => 'This is a test message.']);
@@ -97,7 +97,7 @@ class MiaoxinGatewayTest extends TestCase
             'code' => MiaoxinGateway::SUCCESS_CODE,
             'msg' => '发送成功',
             'total' => 1,
-            'results' => [],
+            'result' => [],
         ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
     }
 
@@ -121,7 +121,7 @@ class MiaoxinGatewayTest extends TestCase
                 'code' => MiaoxinGateway::SUCCESS_CODE,
                 'msg' => '发送成功',
                 'total' => 1,
-                'results' => [],
+                'result' => [],
             ])->once();
 
         $message = new Message(['content' => 'This is a test message.']);
@@ -131,7 +131,7 @@ class MiaoxinGatewayTest extends TestCase
             'code' => MiaoxinGateway::SUCCESS_CODE,
             'msg' => '发送成功',
             'total' => 1,
-            'results' => [],
+            'result' => [],
         ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
     }
 
@@ -156,7 +156,7 @@ class MiaoxinGatewayTest extends TestCase
                 'code' => MiaoxinGateway::SUCCESS_CODE,
                 'msg' => '发送成功',
                 'total' => 1,
-                'results' => [],
+                'result' => [],
             ])->once();
 
         $message = new Message([
@@ -172,7 +172,7 @@ class MiaoxinGatewayTest extends TestCase
             'code' => MiaoxinGateway::SUCCESS_CODE,
             'msg' => '发送成功',
             'total' => 1,
-            'results' => [],
+            'result' => [],
         ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
     }
 
@@ -197,7 +197,7 @@ class MiaoxinGatewayTest extends TestCase
                 'code' => MiaoxinGateway::SUCCESS_CODE,
                 'msg' => '发送成功',
                 'total' => 1,
-                'results' => [],
+                'result' => [],
             ])->once();
 
         $message = new Message([
@@ -213,8 +213,80 @@ class MiaoxinGatewayTest extends TestCase
             'code' => MiaoxinGateway::SUCCESS_CODE,
             'msg' => '发送成功',
             'total' => 1,
-            'results' => [],
+            'result' => [],
         ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
+    }
+
+    public function test_send_with_endpoint_override()
+    {
+        foreach ([
+            [null, MiaoxinGateway::ENDPOINT_HOST],
+            ['', MiaoxinGateway::ENDPOINT_HOST],
+            ['https://sms.example.com', 'https://sms.example.com'],
+            ['https://sms.example.com/', 'https://sms.example.com'],
+        ] as [$endpoint, $expectedHost]) {
+            $config = [
+                'account' => 'mock-account',
+                'secret' => 'mock-secret',
+                'endpoint' => $endpoint,
+            ];
+            $gateway = \Mockery::mock(MiaoxinGateway::class.'[post]', [$config])->shouldAllowMockingProtectedMethods();
+            $result = [
+                'code' => MiaoxinGateway::SUCCESS_CODE,
+                'msg' => '发送成功',
+                'total' => 1,
+                'result' => [
+                    ['mobile' => '18188888888', 'code' => 0, 'msg' => '处理中'],
+                ],
+            ];
+            $gateway->shouldReceive('post')
+                ->with($expectedHost.MiaoxinGateway::SEND_PATH, \Mockery::subset([
+                    'mobiles' => 18188888888,
+                    'content' => 'This is a test message.',
+                ]))
+                ->andReturn($result)->once();
+
+            $this->assertSame($result, $gateway->send(
+                new PhoneNumber(18188888888),
+                new Message(['content' => 'This is a test message.']),
+                new Config($config)
+            ));
+        }
+    }
+
+    public function test_send_throws_when_recipient_fails()
+    {
+        foreach ([
+            [[], ['content' => 'This is a test message.'], MiaoxinGateway::SEND_PATH],
+            [['signature_id' => 123], ['content' => 'This is a test message.'], MiaoxinGateway::FIXED_SIGNATURE_PATH],
+            [[], ['template' => 'mock-tpl-id', 'data' => ['1234']], MiaoxinGateway::TEMPLATE_PATH],
+        ] as [$options, $attributes, $path]) {
+            $config = $options + [
+                'account' => 'mock-account',
+                'secret' => 'mock-secret',
+            ];
+            $gateway = \Mockery::mock(MiaoxinGateway::class.'[post]', [$config])->shouldAllowMockingProtectedMethods();
+            $result = [
+                'code' => MiaoxinGateway::SUCCESS_CODE,
+                'msg' => '发送成功',
+                'total' => 1,
+                'result' => [
+                    ['mobile' => '18188888888', 'code' => -11, 'msg' => '运营商返回异常'],
+                ],
+            ];
+            $gateway->shouldReceive('post')
+                ->with(MiaoxinGateway::ENDPOINT_HOST.$path, \Mockery::subset(['mobiles' => 18188888888]))
+                ->andReturn($result)->once();
+
+            try {
+                $gateway->send(new PhoneNumber(18188888888), new Message($attributes), new Config($config));
+                $this->fail('A failed recipient must raise a gateway error.');
+            } catch (GatewayErrorException $exception) {
+                $this->assertSame(-11, $exception->getCode());
+                $this->assertSame('运营商返回异常', $exception->getMessage());
+                $this->assertSame($result, $exception->raw);
+            }
+        }
     }
 
     public function test_generate_token()

--- a/tests/Gateways/MiaoxinGatewayTest.php
+++ b/tests/Gateways/MiaoxinGatewayTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the overtrue/easy-sms.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Overtrue\EasySms\Tests\Gateways;
+
+use Overtrue\EasySms\Exceptions\GatewayErrorException;
+use Overtrue\EasySms\Gateways\MiaoxinGateway;
+use Overtrue\EasySms\Message;
+use Overtrue\EasySms\PhoneNumber;
+use Overtrue\EasySms\Support\Config;
+use Overtrue\EasySms\Tests\TestCase;
+
+class MiaoxinGatewayTest extends TestCase
+{
+    public function test_send_content()
+    {
+        $config = [
+            'account' => 'mock-account',
+            'secret' => 'mock-secret',
+        ];
+        $gateway = \Mockery::mock(MiaoxinGateway::class.'[post]', [$config])->shouldAllowMockingProtectedMethods();
+
+        $params = [
+            'account' => 'mock-account',
+            'mobiles' => 18188888888,
+            'content' => 'This is a test message.',
+        ];
+        $gateway->shouldReceive('post')
+            ->with(MiaoxinGateway::ENDPOINT_HOST.MiaoxinGateway::SEND_PATH, \Mockery::subset($params))
+            ->andReturn([
+                'code' => MiaoxinGateway::SUCCESS_CODE,
+                'msg' => '发送成功',
+                'total' => 1,
+                'results' => [
+                    ['mobile' => '18188888888', 'order_id' => '1839347820929302091', 'code' => 0, 'msg' => '处理中'],
+                ],
+            ], [
+                'code' => -9102,
+                'msg' => '账号余额不足',
+            ])->times(2);
+
+        $message = new Message(['content' => 'This is a test message.']);
+        $config = new Config($config);
+
+        $this->assertSame([
+            'code' => MiaoxinGateway::SUCCESS_CODE,
+            'msg' => '发送成功',
+            'total' => 1,
+            'results' => [
+                ['mobile' => '18188888888', 'order_id' => '1839347820929302091', 'code' => 0, 'msg' => '处理中'],
+            ],
+        ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
+
+        $this->expectException(GatewayErrorException::class);
+        $this->expectExceptionCode(-9102);
+        $this->expectExceptionMessage('账号余额不足');
+
+        $gateway->send(new PhoneNumber(18188888888), $message, $config);
+    }
+
+    public function test_send_fixed_signature()
+    {
+        $config = [
+            'account' => 'mock-account',
+            'secret' => 'mock-secret',
+            'signature_id' => 123,
+        ];
+        $gateway = \Mockery::mock(MiaoxinGateway::class.'[post]', [$config])->shouldAllowMockingProtectedMethods();
+
+        $params = [
+            'account' => 'mock-account',
+            'mobiles' => 18188888888,
+            'content' => 'This is a test message.',
+            'signatureId' => 123,
+        ];
+        $gateway->shouldReceive('post')
+            ->with(MiaoxinGateway::ENDPOINT_HOST.MiaoxinGateway::FIXED_SIGNATURE_PATH, \Mockery::subset($params))
+            ->andReturn([
+                'code' => MiaoxinGateway::SUCCESS_CODE,
+                'msg' => '发送成功',
+                'total' => 1,
+                'results' => [],
+            ])->once();
+
+        $message = new Message(['content' => 'This is a test message.']);
+        $config = new Config($config);
+
+        $this->assertSame([
+            'code' => MiaoxinGateway::SUCCESS_CODE,
+            'msg' => '发送成功',
+            'total' => 1,
+            'results' => [],
+        ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
+    }
+
+    public function test_send_template()
+    {
+        $config = [
+            'account' => 'mock-account',
+            'secret' => 'mock-secret',
+        ];
+        $gateway = \Mockery::mock(MiaoxinGateway::class.'[post]', [$config])->shouldAllowMockingProtectedMethods();
+
+        $params = [
+            'account' => 'mock-account',
+            'mobiles' => 18188888888,
+            'templateId' => 'mock-tpl-id',
+            'param1' => '1234',
+            'param2' => '张三',
+        ];
+        $gateway->shouldReceive('post')
+            ->with(MiaoxinGateway::ENDPOINT_HOST.MiaoxinGateway::TEMPLATE_PATH, \Mockery::subset($params))
+            ->andReturn([
+                'code' => MiaoxinGateway::SUCCESS_CODE,
+                'msg' => '发送成功',
+                'total' => 1,
+                'results' => [],
+            ])->once();
+
+        $message = new Message([
+            'template' => 'mock-tpl-id',
+            'data' => [
+                'code' => '1234',
+                'name' => '张三',
+            ],
+        ]);
+        $config = new Config($config);
+
+        $this->assertSame([
+            'code' => MiaoxinGateway::SUCCESS_CODE,
+            'msg' => '发送成功',
+            'total' => 1,
+            'results' => [],
+        ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
+    }
+
+    public function test_generate_token()
+    {
+        $gateway = new MiaoxinGateway(['account' => 'mock-account', 'secret' => 'mock-secret']);
+
+        $method = new \ReflectionMethod(MiaoxinGateway::class, 'generateToken');
+        $method->setAccessible(true);
+
+        $this->assertSame(
+            sha1('account=mock-account&ts=20260907120000&secret=mock-secret'),
+            $method->invoke($gateway, 'mock-account', 'mock-secret', '20260907120000')
+        );
+    }
+}

--- a/tests/Gateways/MiaoxinGatewayTest.php
+++ b/tests/Gateways/MiaoxinGatewayTest.php
@@ -101,6 +101,40 @@ class MiaoxinGatewayTest extends TestCase
         ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
     }
 
+    public function test_send_content_with_blank_signature_id()
+    {
+        $config = [
+            'account' => 'mock-account',
+            'secret' => 'mock-secret',
+            'signature_id' => '',
+        ];
+        $gateway = \Mockery::mock(MiaoxinGateway::class.'[post]', [$config])->shouldAllowMockingProtectedMethods();
+
+        $params = [
+            'account' => 'mock-account',
+            'mobiles' => 18188888888,
+            'content' => 'This is a test message.',
+        ];
+        $gateway->shouldReceive('post')
+            ->with(MiaoxinGateway::ENDPOINT_HOST.MiaoxinGateway::SEND_PATH, \Mockery::subset($params))
+            ->andReturn([
+                'code' => MiaoxinGateway::SUCCESS_CODE,
+                'msg' => '发送成功',
+                'total' => 1,
+                'results' => [],
+            ])->once();
+
+        $message = new Message(['content' => 'This is a test message.']);
+        $config = new Config($config);
+
+        $this->assertSame([
+            'code' => MiaoxinGateway::SUCCESS_CODE,
+            'msg' => '发送成功',
+            'total' => 1,
+            'results' => [],
+        ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
+    }
+
     public function test_send_template()
     {
         $config = [
@@ -130,6 +164,47 @@ class MiaoxinGatewayTest extends TestCase
             'data' => [
                 'code' => '1234',
                 'name' => '张三',
+            ],
+        ]);
+        $config = new Config($config);
+
+        $this->assertSame([
+            'code' => MiaoxinGateway::SUCCESS_CODE,
+            'msg' => '发送成功',
+            'total' => 1,
+            'results' => [],
+        ], $gateway->send(new PhoneNumber(18188888888), $message, $config));
+    }
+
+    public function test_send_template_takes_precedence_over_content()
+    {
+        $config = [
+            'account' => 'mock-account',
+            'secret' => 'mock-secret',
+            'signature_id' => 123,
+        ];
+        $gateway = \Mockery::mock(MiaoxinGateway::class.'[post]', [$config])->shouldAllowMockingProtectedMethods();
+
+        $params = [
+            'account' => 'mock-account',
+            'mobiles' => 18188888888,
+            'templateId' => 'mock-tpl-id',
+            'param1' => '1234',
+        ];
+        $gateway->shouldReceive('post')
+            ->with(MiaoxinGateway::ENDPOINT_HOST.MiaoxinGateway::TEMPLATE_PATH, \Mockery::subset($params))
+            ->andReturn([
+                'code' => MiaoxinGateway::SUCCESS_CODE,
+                'msg' => '发送成功',
+                'total' => 1,
+                'results' => [],
+            ])->once();
+
+        $message = new Message([
+            'content' => 'This is a test message.',
+            'template' => 'mock-tpl-id',
+            'data' => [
+                'code' => '1234',
             ],
         ]);
         $config = new Config($config);


### PR DESCRIPTION
新增 [秒信短信平台](http://www.51miaoxin.com) 网关 `MiaoxinGateway`。

- 支持三种发送模式：自定义内容、固定签名、模板短信，自动路由
- 已添加单元测试（4 个测试用例，覆盖三种模式 + token 生成）
- 已更新 README，包含配置说明和使用示例
- 全量测试 94 个全部通过，代码风格检查通过